### PR TITLE
Regenerated recipe with grayskull and bumped version to v0.7.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ test:
     - pip
 
 about:
+  home: https://github.com/glue-viz/glue-wwt
   summary: Glue WorldWide Telescope plugin
   license: BSD-3-Clause
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,28 +1,27 @@
+{% set name = "glue-wwt" %}
 {% set version = "0.7.2" %}
 
 package:
-  name: glue-wwt
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/g/glue-wwt/glue-wwt-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/glue-wwt-{{ version }}.tar.gz
   sha256: 2fbab973c24015f8a99bccddcfe08cf15fccd6e501d922056de0ab8e90f18eab
 
 build:
-  number: 0
-  script: "{{ PYTHON }} -m pip install . -vv"
   noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 1
 
 requirements:
-
   host:
     - python >=3.8
     - pip
-    - setuptools >=30.3
-    - setuptools_scm
-
+    - setuptools >=61.2
+    - setuptools-scm
   run:
-    - python >=3.6
+    - python >=3.8
     - numpy
     - glue-core >=1.13.1
     - echo
@@ -36,13 +35,15 @@ requirements:
 test:
   imports:
     - glue_wwt
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
-  home: https://github.com/glue-viz/glue-wwt
+  summary: Glue WorldWide Telescope plugin
   license: BSD-3-Clause
-  license_family: BSD
   license_file: LICENSE
-  summary: WorldWide Telescope viewer plugin for glue
 
 extra:
   recipe-maintainers:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,2 +1,0 @@
-from glue_wwt import setup
-setup()

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,7 +1,0 @@
-gtk2-devel
-mesa-libGL
-mesa-libGL-devel
-xorg-x11-server-Xorg
-libXtst-devel
-libXScrnSaver
-alsa-lib-devel


### PR DESCRIPTION
I've also removed the Qt dependency here because glue-wwt can be used with glue-jupyter without Qt.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
